### PR TITLE
added type casting to avoid type errors

### DIFF
--- a/main.ml
+++ b/main.ml
@@ -12,11 +12,11 @@ let onestep_xto01 : string -> string list
   then [str]
   else
     let idx = String.index str 'X' in
-    let str1 = str in
-    let str2 = Bytes.copy str in
+    let str1 = Bytes.of_string str in
+    let str2 = Bytes.copy (Bytes.of_string str) in
     let _ = Bytes.set str1 idx '0' in
     let _ = Bytes.set str2 idx '1' in
-    [str1]@[str2]
+    [Bytes.to_string str1]@[Bytes.to_string str2]
 
 (* onestep for all strings *)
 let onestep_strlst : string list -> string list 


### PR DESCRIPTION
Fixed two errors by adding str_to_bytes and bytes_to_string in the code that unroll X (arbitrary bit) examples.