### PR TITLE
Bringing AlphaRegexPublic up-to-date with dune

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+_build
+dune-project
+*~

--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ After you clone this project, follow the steps below.
 -   Activate the build script: ```chmod +x build```.
 -   Complie the whole files using the script: ```./build```.
 
+## How to build with dune:
+Simply run ```dune build main.exe```.
+
+
 ## How to use
 To use AlphaRegex, you need to provide:
 -   Positive examples

--- a/dune
+++ b/dune
@@ -1,0 +1,7 @@
+(executable
+ (name main) 
+(libraries base batteries))
+
+(env
+  (dev
+    (flags (:standard -warn-error -A))))

--- a/main.ml
+++ b/main.ml
@@ -83,7 +83,8 @@ let main () =
      (match pgm with
       | None -> print_endline "Fail to synthesize"
       | Some pgm -> 
-        let _ = pp pgm in
+         let _ = pp pgm in
+         print_endline ("Size = " ^ string_of_int( cost(pgm)) );
           print_endline ("Level: " ^ string_of_int (level pgm));
           sanity_check pgm pos_examples neg_examples;
           print_endline "============  REPORT  =============";

--- a/main.ml
+++ b/main.ml
@@ -12,11 +12,11 @@ let onestep_xto01 : string -> string list
   then [str]
   else
     let idx = String.index str 'X' in
-    let str1 = str in
-    let str2 = Bytes.copy str in
+    let str1 = Bytes.of_string str in
+    let str2 = Bytes.copy (Bytes.of_string str) in
     let _ = Bytes.set str1 idx '0' in
     let _ = Bytes.set str2 idx '1' in
-    [str1]@[str2]
+    [Bytes.to_string str1]@[Bytes.to_string str2]
 
 (* onestep for all strings *)
 let onestep_strlst : string list -> string list 

--- a/runall
+++ b/runall
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+EXEC=_build/default/main.exe
+DIR=benchmarks
+ALL=" no1_start_with_0 \
+ no2_end_with_01 \
+ no3_substring_0101 \
+ no4_begin_1_end_0 \
+ no5_length_at_least3_and_third_0 \
+ no6_len_is_3_mul \
+ no7_zeros_divisible_by_3 \
+ no8_even_zeros \
+ no9_5th1 \
+ no10_alternating  no11_0_followed_by_atleast_one_1 \
+ no12_n_is_ge_3_m_is_even \
+ no13_atmost_2zeros \
+ no14_start_cond \
+ no15_except_0_and_1 \
+ no16_not_end_with_01 \
+ no17_atleastone0_atmostone1 \
+ no18_0110 \
+ no19_not_contain_substring_100 \
+ no20_odd_pos_is_1 \
+ no21_exactly_00_once \
+ no22_atleast2_and_not_end_with_10 \
+ no23_even_0s_and_followed_by_atleast_one_1 \
+ no24_00_before_11 \
+ no25_atmost_one_pair_of_11"
+
+for e in ${ALL}
+do
+   echo ----------- ${e} -----------
+   echo ${EXEC} -input
+   ${EXEC} -input benchmarks/${e}	
+done
+
+
+
+

--- a/runall
+++ b/runall
@@ -2,36 +2,11 @@
 
 EXEC=_build/default/main.exe
 DIR=benchmarks
-ALL=" no1_start_with_0 \
- no2_end_with_01 \
- no3_substring_0101 \
- no4_begin_1_end_0 \
- no5_length_at_least3_and_third_0 \
- no6_len_is_3_mul \
- no7_zeros_divisible_by_3 \
- no8_even_zeros \
- no9_5th1 \
- no10_alternating  no11_0_followed_by_atleast_one_1 \
- no12_n_is_ge_3_m_is_even \
- no13_atmost_2zeros \
- no14_start_cond \
- no15_except_0_and_1 \
- no16_not_end_with_01 \
- no17_atleastone0_atmostone1 \
- no18_0110 \
- no19_not_contain_substring_100 \
- no20_odd_pos_is_1 \
- no21_exactly_00_once \
- no22_atleast2_and_not_end_with_10 \
- no23_even_0s_and_followed_by_atleast_one_1 \
- no24_00_before_11 \
- no25_atmost_one_pair_of_11"
 
-for e in ${ALL}
+for e in ${DIR}/*
 do
    echo ----------- ${e} -----------
-   echo ${EXEC} -input
-   ${EXEC} -input benchmarks/${e}	
+   ${EXEC} -input ${e}	
 done
 
 


### PR DESCRIPTION
Several small updates, to bring AlphaRegexPublic up-to-date with 2021 OCaml technology:

- Added a very basic dune script (and added a .gitignore to make git less noisy when using dune)
- Fixed the type-casting errors following the pull request https://github.com/kupl/AlphaRegexPublic/pull/3
- Added a note on the dune build